### PR TITLE
Bugfix - fedora needs libaio not libaio1

### DIFF
--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -9,7 +9,7 @@
   {%- set archive_file3 = sqlplus.prefix + '/' + sqlplus.source_url3.split('/') | last %}
 
 #runtime dependency
-sqldeveloper-libaio1:
+sqlplus-libaio1:
   pkg.installed:
     {%- if salt['grains.get']('os') == 'Ubuntu' %}
     - name: libaio1

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -8,9 +8,14 @@
   {%- set archive_file2 = sqlplus.prefix + '/' + sqlplus.source_url2.split('/') | last %}
   {%- set archive_file3 = sqlplus.prefix + '/' + sqlplus.source_url3.split('/') | last %}
 
-sqlplus-libaio1:
+#runtime dependency
+sqldeveloper-libaio1:
   pkg.installed:
+    {%- if salt['grains.get']('os') == 'Ubuntu' %}
     - name: libaio1
+    {%- else %}
+    - name: libaio
+    {%- endif %}
 
 sqlplus-install-dir:
   file.directory:


### PR DESCRIPTION
Added logic to select correct package name in ubuntu vs fedora.