### PR TITLE
Essential updates for older Salt versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,11 @@ sqlplus-formula
 
 This formula will set up and configure Oracle SqlPlus client sourced from URL.
 
-.. note::
+.. note1::
+
+   The SOURCE URI in settings.sls must be updated with your internal mirror.
+
+.. note2::
 
     See the full `Salt Formulas installation and usage instructions
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.

--- a/sqlplus/env.sls
+++ b/sqlplus/env.sls
@@ -25,7 +25,7 @@ sqlplushome-alt-set:
   - name: sqlplus-home
   - path: {{ sqlplus.sqlplus_real_home }}
   - require:
-    - sqlplushome-alt-install
+    - alternatives: sqlplushome-alt-install
 
 # Add sqlplus to alternatives system
 sqlplus-alt-install:
@@ -35,14 +35,14 @@ sqlplus-alt-install:
     - path: {{ sqlplus.sqlplus_realcmd }}
     - priority: {{ sqlplus.alt_priority }}
     - require:
-      - sqlplushome-alt-set
+      - alternatives: sqlplushome-alt-set
 
 sqlplus-alt-set:
   alternatives.set:
   - name: sqlplus
   - path: {{ sqlplus.sqlplus_realcmd }}
   - require:
-    - sqlplus-alt-install
+    - alternatives: sqlplus-alt-install
 
 create /etc/tnsnames.ora:
   file.managed:
@@ -53,5 +53,5 @@ create /etc/tnsnames.ora:
     - user: root
     - group: root
     - require:
-      - sqlplus-alt-set
+      - alternatives: sqlplus-alt-set
 

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -11,7 +11,7 @@
 #runtime dependency
 sqlplus-libaio1:
   pkg.installed:
-    {%- if salt['grains.get']('os') == 'Ubuntu' %}
+    {%- if salt['grains.get']('os') == 'Ubuntu' or salt['grains.get']('os') == 'SUSE' %}
     - name: libaio1
     {%- else %}
     - name: libaio
@@ -54,11 +54,12 @@ sqlplus-unpack-instantclient-basic-archive:
     {%- if sqlplus.source_hash1 %}
     - source_hash: {{ sqlplus.source_hash1 }}
     {%- endif %}
+    {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: {{ sqlplus.sqlplus_realcmd }}
+    {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - user: root
-    - group: root
     - require:
-      - sqlplus-download-instantclient-basic-archive
+      - cmd: sqlplus-download-instantclient-basic-archive
 
 sqlplus-unpack-instantclient-sqlplus-archive:
   archive.extracted:
@@ -67,11 +68,12 @@ sqlplus-unpack-instantclient-sqlplus-archive:
     {%- if sqlplus.source_hash2 %}
     - source_hash: {{ sqlplus.source_hash2 }}
     {%- endif %}
+    {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: {{ sqlplus.sqlplus_realcmd }}
+    {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - user: root
-    - group: root
     - require:
-      - sqlplus-download-instantclient-sqlplus-archive
+      - cmd: sqlplus-download-instantclient-sqlplus-archive
 
 sqlplus-unpack-instantclient-devel-archive:
   archive.extracted:
@@ -80,19 +82,20 @@ sqlplus-unpack-instantclient-devel-archive:
     {%- if sqlplus.source_hash3 %}
     - source_hash: {{ sqlplus.source_hash3 }}
     {%- endif %}
+    {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: {{ sqlplus.sqlplus_realcmd }}
+    {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - user: root
-    - group: root
     - require:
-      - sqlplus-download-instantclient-devel-archive
+      - cmd: sqlplus-download-instantclient-devel-archive
 
 sqlplus-update-home-symlink:
   cmd.run:
     - name: mv {{ sqlplus.sqlplus_unpackdir }} {{ sqlplus.sqlplus_real_home }}
     - require:
-      - sqlplus-unpack-instantclient-basic-archive
-      - sqlplus-unpack-instantclient-sqlplus-archive
-      - sqlplus-unpack-instantclient-devel-archive
+      - archive: sqlplus-unpack-instantclient-basic-archive
+      - archive: sqlplus-unpack-instantclient-sqlplus-archive
+      - archive: sqlplus-unpack-instantclient-devel-archive
   file.symlink:
     - name: {{ sqlplus.orahome }}/sqlplus
     - target: {{ sqlplus.sqlplus_real_home }}
@@ -105,7 +108,7 @@ sqlplus-desktop-entry:
     - source: salt://sqlplus/files/sqlplus.desktop
     - name: /home/{{ pillar['user'] }}/Desktop/sqlplus.desktop
     - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' %}
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE'%}
     - group: users
 {% else %}
     - group: {{ pillar['user'] }}
@@ -121,8 +124,8 @@ sqlplus-remove-instantclient-archives:
       - {{ archive_file2 }}
       - {{ archive_file3 }}
     - require:
-      - sqlplus-unpack-instantclient-basic-archive
-      - sqlplus-unpack-instantclient-sqlplus-archive
-      - sqlplus-unpack-instantclient-devel-archive
+      - archive: sqlplus-unpack-instantclient-basic-archive
+      - archive: sqlplus-unpack-instantclient-sqlplus-archive
+      - archive: sqlplus-unpack-instantclient-devel-archive
 
 {%- endif %}


### PR DESCRIPTION
This PR addresses a number of issues in the existing formula.

1. **Salt 2015.8.8 (Beryllium) generates "Requisite declaration XXXXXXXXXXX in SLS sqlplus is not formed as a single key dictionary"  errors on requires-**

	Solution:  prefix requisite-type to all requires (i.e. - cmd: download-sqlplus-xx-archive ).

2.  **Salt 2016.3 on OpenSuSE Leap evaluates "salt['grains.get']('os_family') == 'Suse'" as False.**

	Solution:  Trying "salt['grains.get']('os') == 'SUSE'"  evaluates as True, fixed!!

3. **Current "saltversion" check does not work on opensuse leap.**

       Solution: Twooster on #salt IRC suggested "{% if grains['saltversioninfo'] <= [2016, 11, 6] %}" which works!!

4. . **Salt generates warnings on Fedora regarding https://github.com/saltstack/salt/issues/39751**

        Solution: Remove "user: root" and "group: root" from archive.extracted state.

5.  **On older Salt version the archive is never extracted because directory "name" exists!**

        Solution: Reintroduce "if_missing" parameter to archive.extracted for older Salt.

6.  **The "sqlplus-libaio1" state fails on opensuse Leap.**

        Solution:  Install libaio1 package if grains.get('os') == SUSE.

Tested successfuly (no pillars):
- Fedora 25 / Salt 2016.11.3.1.fc25
- Ubunutu 17 / Salt 2017.7.0+ds-1
- Opensuse Leap / Salt 2016.3.4.84.13