### PR TITLE
use onchanges clause; remove desktop icon; fix hashchecks in older salt

### DIFF
--- a/sqlplus/env.sls
+++ b/sqlplus/env.sls
@@ -26,8 +26,6 @@ sqlplushome-alt-set:
   - path: {{ sqlplus.sqlplus_real_home }}
   - require:
     - alternatives: sqlplushome-alt-install
-  - onchanges:
-    - alternatives: sqlplushome-alt-install
 
 # Add sqlplus to alternatives system
 sqlplus-alt-install:

--- a/sqlplus/env.sls
+++ b/sqlplus/env.sls
@@ -59,4 +59,5 @@ create /etc/tnsnames.ora:
     - mode: 644
     - user: root
     - group: root
+    - if_missing: /etc/tnsnames.ora
 

--- a/sqlplus/env.sls
+++ b/sqlplus/env.sls
@@ -26,6 +26,8 @@ sqlplushome-alt-set:
   - path: {{ sqlplus.sqlplus_real_home }}
   - require:
     - alternatives: sqlplushome-alt-install
+  - onchanges:
+    - alternatives: sqlplushome-alt-install
 
 # Add sqlplus to alternatives system
 sqlplus-alt-install:
@@ -36,12 +38,17 @@ sqlplus-alt-install:
     - priority: {{ sqlplus.alt_priority }}
     - require:
       - alternatives: sqlplushome-alt-set
+    - onchanges:
+      - alternatives: sqlplushome-alt-install
+      - alternatives: sqlplushome-alt-set
 
 sqlplus-alt-set:
   alternatives.set:
   - name: sqlplus
   - path: {{ sqlplus.sqlplus_realcmd }}
   - require:
+    - alternatives: sqlplus-alt-install
+  - onchanges:
     - alternatives: sqlplus-alt-install
 
 create /etc/tnsnames.ora:
@@ -52,6 +59,4 @@ create /etc/tnsnames.ora:
     - mode: 644
     - user: root
     - group: root
-    - require:
-      - alternatives: sqlplus-alt-set
 

--- a/sqlplus/env.sls
+++ b/sqlplus/env.sls
@@ -24,7 +24,7 @@ sqlplushome-alt-set:
   alternatives.set:
   - name: sqlplus-home
   - path: {{ sqlplus.sqlplus_real_home }}
-  - require:
+  - onchanges:
     - alternatives: sqlplushome-alt-install
 
 # Add sqlplus to alternatives system
@@ -34,8 +34,6 @@ sqlplus-alt-install:
     - link: {{ sqlplus.sqlplus_symlink }}
     - path: {{ sqlplus.sqlplus_realcmd }}
     - priority: {{ sqlplus.alt_priority }}
-    - require:
-      - alternatives: sqlplushome-alt-set
     - onchanges:
       - alternatives: sqlplushome-alt-install
       - alternatives: sqlplushome-alt-set
@@ -44,8 +42,6 @@ sqlplus-alt-set:
   alternatives.set:
   - name: sqlplus
   - path: {{ sqlplus.sqlplus_realcmd }}
-  - require:
-    - alternatives: sqlplus-alt-install
   - onchanges:
     - alternatives: sqlplus-alt-install
 

--- a/sqlplus/files/sqlplus.desktop
+++ b/sqlplus/files/sqlplus.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Name=SQL Plus
-Comment=Oracle SQL Plus
-Icon=/opt/sqlplus/icon.png
-Exec=sqlplus
-Terminal=false
-Type=Application

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -58,8 +58,6 @@ sqlplus-unpack-instantclient-basic-archive:
     - if_missing: {{ sqlplus.sqlplus_realcmd }}
     {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - require:
-      - cmd: sqlplus-download-instantclient-basic-archive
     - onchanges:
       - cmd: sqlplus-download-instantclient-basic-archive
 
@@ -74,8 +72,6 @@ sqlplus-unpack-instantclient-sqlplus-archive:
     - if_missing: {{ sqlplus.sqlplus_realcmd }}
     {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - require:
-      - cmd: sqlplus-download-instantclient-sqlplus-archive
     - onchanges:
       - cmd: sqlplus-download-instantclient-sqlplus-archive
 
@@ -90,18 +86,12 @@ sqlplus-unpack-instantclient-devel-archive:
     - if_missing: {{ sqlplus.sqlplus_realcmd }}
     {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
-    - require:
-      - cmd: sqlplus-download-instantclient-devel-archive
     - onchanges:
       - cmd: sqlplus-download-instantclient-devel-archive
 
 sqlplus-update-home-symlink:
   cmd.run:
     - name: mv {{ sqlplus.sqlplus_unpackdir }} {{ sqlplus.sqlplus_real_home }}
-    - require:
-      - archive: sqlplus-unpack-instantclient-basic-archive
-      - archive: sqlplus-unpack-instantclient-sqlplus-archive
-      - archive: sqlplus-unpack-instantclient-devel-archive
     - onchanges:
       - archive: sqlplus-unpack-instantclient-basic-archive
       - archive: sqlplus-unpack-instantclient-sqlplus-archive
@@ -110,8 +100,6 @@ sqlplus-update-home-symlink:
     - name: {{ sqlplus.orahome }}/sqlplus
     - target: {{ sqlplus.sqlplus_real_home }}
     - force: True
-    - require:
-      - cmd: sqlplus-update-home-symlink
     - onchanges:
       - cmd: sqlplus-update-home-symlink
 

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -103,20 +103,6 @@ sqlplus-update-home-symlink:
     - onchanges:
       - cmd: sqlplus-update-home-symlink
 
-sqlplus-desktop-entry:
-  file.managed:
-    - source: salt://sqlplus/files/sqlplus.desktop
-    - name: /home/{{ pillar['user'] }}/Desktop/sqlplus.desktop
-    - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE'%}
-    - group: users
-{% else %}
-    - group: {{ pillar['user'] }}
-{% endif %}
-    - mode: 755
-    - require:
-      - file: sqlplus-update-home-symlink
-
 sqlplus-remove-instantclient-archives:
   file.absent:
     - names:

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -60,6 +60,8 @@ sqlplus-unpack-instantclient-basic-archive:
     - archive_format: {{ sqlplus.archive_type }}
     - require:
       - cmd: sqlplus-download-instantclient-basic-archive
+    - onchanges:
+      - cmd: sqlplus-download-instantclient-basic-archive
 
 sqlplus-unpack-instantclient-sqlplus-archive:
   archive.extracted:
@@ -73,6 +75,8 @@ sqlplus-unpack-instantclient-sqlplus-archive:
     {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
     - require:
+      - cmd: sqlplus-download-instantclient-sqlplus-archive
+    - onchanges:
       - cmd: sqlplus-download-instantclient-sqlplus-archive
 
 sqlplus-unpack-instantclient-devel-archive:
@@ -88,6 +92,8 @@ sqlplus-unpack-instantclient-devel-archive:
     - archive_format: {{ sqlplus.archive_type }}
     - require:
       - cmd: sqlplus-download-instantclient-devel-archive
+    - onchanges:
+      - cmd: sqlplus-download-instantclient-devel-archive
 
 sqlplus-update-home-symlink:
   cmd.run:
@@ -101,6 +107,8 @@ sqlplus-update-home-symlink:
     - target: {{ sqlplus.sqlplus_real_home }}
     - force: True
     - require:
+      - cmd: sqlplus-update-home-symlink
+    - onchanges:
       - cmd: sqlplus-update-home-symlink
 
 sqlplus-desktop-entry:

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -102,6 +102,10 @@ sqlplus-update-home-symlink:
       - archive: sqlplus-unpack-instantclient-basic-archive
       - archive: sqlplus-unpack-instantclient-sqlplus-archive
       - archive: sqlplus-unpack-instantclient-devel-archive
+    - onchanges:
+      - archive: sqlplus-unpack-instantclient-basic-archive
+      - archive: sqlplus-unpack-instantclient-sqlplus-archive
+      - archive: sqlplus-unpack-instantclient-devel-archive
   file.symlink:
     - name: {{ sqlplus.orahome }}/sqlplus
     - target: {{ sqlplus.sqlplus_real_home }}

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -32,18 +32,51 @@ sqlplus-download-instantclient-basic-archive:
     - name: curl {{ sqlplus.dl_opts }} -o '{{ archive_file1 }}' '{{ sqlplus.source_url1 }}'
     - require:
       - file: sqlplus-install-dir
+  {% if grains['saltversioninfo'] <= [2016, 11, 6] and sqlplus.source_hash1 %}
+    # See: https://github.com/saltstack/salt/pull/41914 ensure hashchk in older salt.
+  module.run:
+    - name: file.check_hash
+    - path: {{ archive_file1 }}
+    - file_hash: {{ sqlplus.source_hash1 }}
+    - onchanges:
+      - cmd: sqlplus-download-instantclient-basic-archive
+    - require_in:
+      - archive: sqlplus-unpack-instantclient-basic-archive
+  {%- endif %}
 
 sqlplus-download-instantclient-sqlplus-archive:
   cmd.run:
     - name: curl {{ sqlplus.dl_opts }} -o '{{ archive_file2 }}' '{{ sqlplus.source_url2 }}'
     - require:
       - file: sqlplus-install-dir
+ {% if grains['saltversioninfo'] <= [2016, 11, 6] and sqlplus.source_hash2 %}
+    # See: https://github.com/saltstack/salt/pull/41914 ensure hashchk in older salt.
+  module.run:
+    - name: file.check_hash
+    - path: {{ archive_file2 }}
+    - file_hash: {{ sqlplus.source_hash2 }}
+    - onchanges:
+      - cmd: sqlplus-download-instantclient-sqlplus-archive
+    - require_in:
+      - archive: sqlplus-unpack-instantclient-sqlplus-archive
+ {%- endif %}
 
 sqlplus-download-instantclient-devel-archive:
   cmd.run:
     - name: curl {{ sqlplus.dl_opts }} -o '{{ archive_file3 }}' '{{ sqlplus.source_url3 }}'
     - require:
       - file: sqlplus-install-dir
+ {% if grains['saltversioninfo'] <= [2016, 11, 6] and sqlplus.source_hash3 %}
+    # See: https://github.com/saltstack/salt/pull/41914 ensure hashchk in older salt.
+  module.run:
+    - name: file.check_hash
+    - path: {{ archive_file3 }}
+    - file_hash: {{ sqlplus.source_hash3 }}
+    - onchanges:
+      - cmd: sqlplus-download-instantclient-devel-archive
+    - require_in:
+      - archive: sqlplus-unpack-instantclient-devel-archive
+ {%- endif %}
 
 sqlplus-unpack-instantclient-basic-archive:
   file.absent:
@@ -51,13 +84,15 @@ sqlplus-unpack-instantclient-basic-archive:
   archive.extracted:
     - name: {{ sqlplus.prefix }}
     - source: file://{{ archive_file1 }}
-    {%- if sqlplus.source_hash1 %}
+    {%- if sqlplus.source_hash1 and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ sqlplus.source_hash1 }}
     {%- endif %}
     {% if grains['saltversioninfo'] < [2016, 11, 0] %}
     - if_missing: {{ sqlplus.sqlplus_realcmd }}
     {% endif %}
     - archive_format: {{ sqlplus.archive_type }}
+    - require:
+      - file: sqlplus-unpack-instantclient-basic-archive
     - onchanges:
       - cmd: sqlplus-download-instantclient-basic-archive
 
@@ -65,7 +100,7 @@ sqlplus-unpack-instantclient-sqlplus-archive:
   archive.extracted:
     - name: {{ sqlplus.prefix }}
     - source: file://{{ archive_file2 }}
-    {%- if sqlplus.source_hash2 %}
+    {%- if sqlplus.source_hash2 and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ sqlplus.source_hash2 }}
     {%- endif %}
     {% if grains['saltversioninfo'] < [2016, 11, 0] %}
@@ -79,7 +114,7 @@ sqlplus-unpack-instantclient-devel-archive:
   archive.extracted:
     - name: {{ sqlplus.prefix }}
     - source: file://{{ archive_file3 }}
-    {%- if sqlplus.source_hash3 %}
+    {%- if sqlplus.source_hash3 and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ sqlplus.source_hash3 }}
     {%- endif %}
     {% if grains['saltversioninfo'] < [2016, 11, 0] %}
@@ -100,7 +135,7 @@ sqlplus-update-home-symlink:
     - name: {{ sqlplus.orahome }}/sqlplus
     - target: {{ sqlplus.sqlplus_real_home }}
     - force: True
-    - onchanges:
+    - require:
       - cmd: sqlplus-update-home-symlink
 
 sqlplus-remove-instantclient-archives:
@@ -109,7 +144,7 @@ sqlplus-remove-instantclient-archives:
       - {{ archive_file1 }}
       - {{ archive_file2 }}
       - {{ archive_file3 }}
-    - require:
+    - onchanges:
       - archive: sqlplus-unpack-instantclient-basic-archive
       - archive: sqlplus-unpack-instantclient-sqlplus-archive
       - archive: sqlplus-unpack-instantclient-devel-archive

--- a/sqlplus/settings.sls
+++ b/sqlplus/settings.sls
@@ -9,7 +9,7 @@
 {%- set version      = g.get('version', p.get('version', release + '.' + minor + '.0.1.0' )) %}
 {%- set sqlplus_name = 'instantclient' %}
 
-{# ######## YOU MUST CHANGE TO LOCAL MIRROR DUE TO LICENSE ACCEPTANCE/LOGIN REQ. ####### #}
+{########## YOU MUST CHANGE THIS URL TO YOUR LOCAL MIRROR ####### #}
 {%- set mirror  = 'http://download.oracle.com/otn/linux/instantclient/' + release + minor + '010/' %}
 
 {%- set default_archive_type = 'zip' %}
@@ -18,6 +18,8 @@
 {%- set default_source_url1  = mirror + 'instantclient-basic' + suffix %}
 {%- set default_source_url2  = mirror + 'instantclient-sqlplus' + suffix %}
 {%- set default_source_url3  = mirror + 'instantclient-sdk' + suffix %}
+
+  ##### Hashes for version 12.2 lixux binary zipfile #####
 {%- set default_source_hash1 = 'md5=d9639092e3dea2e023272e52e2bd42da' %}
 {%- set default_source_hash2 = 'md5=93ae87df1d08bb31da57443a416edc8c' %}
 {%- set default_source_hash3 = 'md5=077fa2f215185377ccb670de9ca1678f' %}


### PR DESCRIPTION
Small incremental improvements:

(1) sqlplus or sqlplus.env state failure triggers unnecessary dep-states failure => use onchanges.

(2) Remove desktop icon - this is command line utility.

(3) Ensure hashcheck happens for older salt versions.