### PR TITLE
Add Suse Support / Minor fixes and updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ This formula installs the version of sqlplus defined as default. Can be overridd
 
 ``sqlplus.developer``
 ------------
-Optionally download a 'tnsnames.ora' file from url/share and save into 'user' (pillar) home directory.
+Optionally retrieve 'tnsnames.ora' file from url/share into 'user' (pillar) home directory for export/import support.
 
 
 ``sqlplus.linuxenv``

--- a/pillar.example
+++ b/pillar.example
@@ -15,7 +15,7 @@ sqlplus:
       #sqlplus: md5=0c23f99617f6c2d11ac6df1704c7cd85
   linux:
     #Increase priority for every version installed
-    priority: 190
+    altpriority: 190
   dl:
     retries: 1
     interval: 30

--- a/sqlplus/defaults.yaml
+++ b/sqlplus/defaults.yaml
@@ -28,6 +28,5 @@ sqlplus:
     ldconfig: no
 
   prefs:
-    user: undefined_user
     tnsnamesurl: undefined
     tnsnamesfile: undefined

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -1,14 +1,5 @@
 {% from "sqlplus/map.jinja" import sqlplus with context %}
 
-#runtime dependency
-sqlplus-libaio1:
-  pkg.installed:
-    {% if grains.os in ('Ubuntu', 'Suse', 'SUSE') %}
-    - name: libaio1
-    {%- else %}
-    - name: libaio
-    {%- endif %}
-
 sqlplus-create-extract-dirs:
   file.directory:
     - names:


### PR DESCRIPTION
This pull request includes minor enhancements:
1. SUSE support
2. Tidyup README
3. Remove superfluous 'user' ID from defaults.yaml
4. Fix duplicate ID conflict beween init.sls and linuxenv sls files.

Suse support verified on OpenSUSE LEAP (42).

[verification_suse.log](https://github.com/saltstack-formulas/sqlplus-formula/files/1438990/verification_suse.log)
