### PR TITLE
Minor fixes for SQLPLUS init & developer states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,7 @@ On Linux, the PATH is set for all system users by adding software profile to /et
 
 .. note::
 
-The linux-alternatives 'priority' pillar value must be updated for each newly installed release/editions.
-
+Enable Debian alternatives by setting nonzero 'altpriority' pillar value; otherwise feature is disabled.
 
 Please see the pillar.example for configuration.
 Tested on Linux (Ubuntu, Fedora, Arch, and Suse), MacOS. Not verified on Windows OS.

--- a/pillar.example
+++ b/pillar.example
@@ -14,8 +14,9 @@ sqlplus:
       #sdk: md5=6791925e182d534a8143847263157d8f'
       #sqlplus: md5=0c23f99617f6c2d11ac6df1704c7cd85
   linux:
-    #Increase priority for every version installed
-    altpriority: 190
+    #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
+    #Increase same value on each subsequent software installation.
+    #altpriority: 170
   dl:
     retries: 1
     interval: 30

--- a/sqlplus/defaults.yaml
+++ b/sqlplus/defaults.yaml
@@ -23,9 +23,10 @@ sqlplus:
     skip_hashcheck: False
 
   linux:
-    symlink: /usr/local/bin/sqlplus
-    altpriority: 170
     ldconfig: no
+    symlink: /usr/local/bin/sqlplus
+    #debian alternatives is disabled by default. Activated via pillar value.
+    altpriority: 0
 
   prefs:
     tnsnamesurl: undefined

--- a/sqlplus/developer.sls
+++ b/sqlplus/developer.sls
@@ -2,6 +2,8 @@
 
 {% if sqlplus.prefs.tnsnamesurl not in (None, 'undefined') %}
 
+  {% if grains.os not in ('Windows') %}
+
 sqlplus-tnsnames-ora:
   cmd.run:
     - name: curl {{ sqlplus.dl.opts }} -o /etc/tnsnames.ora '{{ sqlplus.prefs.tnsnamesurl }}'
@@ -12,6 +14,8 @@ sqlplus-tnsnames-ora:
         attempts: {{ sqlplus.dl.retries }}
         interval: {{ sqlplus.dl.interval }}
     {% endif %}
+
+  {% endif %}
 
 {%- endif %}
 

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -4,8 +4,9 @@ sqlplus-create-extract-dirs:
   file.directory:
     - names:
       - '{{ sqlplus.tmpdir }}'
-      - '{{ sqlplus.oracle.realhome }}'
+      - '{{ sqlplus.oracle.home }}'
   {% if grains.os not in ('MacOS', 'Windows') %}
+      - '{{ sqlplus.oracle.realhome }}'
     - user: root
     - group: root
     - mode: 755

--- a/sqlplus/linuxenv.sls
+++ b/sqlplus/linuxenv.sls
@@ -58,9 +58,9 @@ sqlplus-ldconfig:
 
   {% endif %}
 
-## Debian Alternatives ##
-
-  {% if grains.os_family not in ('Arch') %}
+  ## Debian Alternatives ##
+  {% if sqlplus.linux.altpriority > 0 %}
+     {% if grains.os_family not in ('Arch') %}
 
 # Add swhome to alternatives system
 sqlplus-home-alt-install:
@@ -100,6 +100,7 @@ sqlplus-alt-set:
     - onchanges:
       - alternatives: sqlplus-alt-install
 
+     {% endif %}
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
PR to fix two minor issues-

1) **sqlplus.developer** not verified on Windows => add elif not 'Windows'
2) **sqlplus.init** must ensure /opt/jetbrains (**intellij.jetbrains.home**) directory exists
3) Enable Debian Alternatives via 'altpriority' pillar (otherwise disabled)

Verified on OpenSUSE Leap