### PR TITLE
Minor update for skip_hashcheck_check

### DIFF
--- a/sqlplus/defaults.yaml
+++ b/sqlplus/defaults.yaml
@@ -20,7 +20,7 @@ sqlplus:
     interval: 30
     retries: 1
     suffix: zip
-    skip_hashcheck: False
+    skip_hashcheck:
 
   linux:
     ldconfig: no

--- a/sqlplus/init.sls
+++ b/sqlplus/init.sls
@@ -30,7 +30,7 @@ sqlplus-extract-{{ pkg }}:
       - sqlplus-create-extract-dirs
     - require_in:
       - archive: sqlplus-extract-{{ pkg }}
-  {% if sqlplus.dl.skip_hashcheck in ('None', 'False', 'false', 'FALSE') %}
+  {% if sqlplus.dl.skip_hashcheck not in ('True', True) %}
   module.run:
     - name: file.check_hash
     - path: '{{ sqlplus.tmpdir }}/{{ pkg }}.{{ sqlplus.dl.suffix }}'


### PR DESCRIPTION
This Pull Request resolves #12.  Verified on OpenSUSE.

**Pillar**

```
sqlplus:
  oracle:
    uri: http://example.com/downloads/
    version: 12.2.0.1.0
    md5:
      #linux.x64 package cksums
      basic: md5=d9639092e3dea2e023272e52e2bd42da
      sqlplus: md5=93ae87df1d08bb31da57443a416edc8c
      sdk: md5=077fa2f215185377ccb670de9ca1678f
  linux:
    altpriority: 191
```

**OpenSUSE**

```
ID: sqlplus-extract-basic
    Function: archive.extracted
        Name: /usr/share/oracle/12_2/
      Result: True
     Comment: /tmp/oracletmp/basic.zip extracted to /usr/share/oracle/12_2/, due to absence of one or more files/dirs
     Started: 19:30:10.793834
    Duration: 1856.231 ms


          ID: sqlplus-extract-sdk
    Function: archive.extracted
        Name: /usr/share/oracle/12_2/
      Result: True
     Comment: /tmp/oracletmp/sdk.zip extracted to /usr/share/oracle/12_2/, due to absence of one or more files/dirs
     Started: 19:30:16.177205
    Duration: 27.208 ms

          ID: sqlplus-extract-sqlplus
    Function: archive.extracted
        Name: /usr/share/oracle/12_2/
      Result: True
     Comment: /tmp/oracletmp/sqlplus.zip extracted to /usr/share/oracle/12_2/, due to absence of one or more files/dirs
     Started: 19:30:21.611450
    Duration: 33.544 ms

```